### PR TITLE
Temp tables for ids

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,5 @@
+^renv$
+^renv\.lock$
 ^.*\.Rproj$
 ^\.Rproj\.user$
 .gitattributes

--- a/R/SelfControlledCohort.R
+++ b/R/SelfControlledCohort.R
@@ -223,6 +223,9 @@ runSelfControlledCohort <- function(connectionDetails,
     conn <- connectionDetails$conn
   }
 
+  DatabaseConnector::insertTable(conn, "tempdb..#scc_outcome_ids", data.frame(outcome_id = outcomeIds))
+  DatabaseConnector::insertTable(conn, "tempdb..#scc_exposure_ids", data.frame(exposure_id = exposureIds))
+
   renderedSql <- SqlRender::loadRenderTranslateSql(sqlFilename = "Scc.sql",
                                                    packageName = "SelfControlledCohort",
                                                    dbms = connectionDetails$dbms,

--- a/inst/sql/sql_server/Scc.sql
+++ b/inst/sql/sql_server/Scc.sql
@@ -103,14 +103,14 @@ FROM (
 			exposure_start_date,
 			exposure_end_date
 		FROM (
-			SELECT @exposure_person_id AS person_id,
-				@exposure_id AS exposure_id,
-				@exposure_start_date AS exposure_start_date,
-				@exposure_end_date AS exposure_end_date
-				{@first_exposure_only} ? {,ROW_NUMBER() OVER (PARTITION BY @exposure_person_id, @exposure_id ORDER BY @exposure_start_date) AS rn1}
+			SELECT et.@exposure_person_id AS person_id,
+				et.@exposure_id AS exposure_id,
+				et.@exposure_start_date AS exposure_start_date,
+				et.@exposure_end_date AS exposure_end_date
+				{@first_exposure_only} ? {,ROW_NUMBER() OVER (PARTITION BY et.@exposure_person_id, et.@exposure_id ORDER BY et.@exposure_start_date) AS rn1}
 			FROM
-				@exposure_database_schema.@exposure_table
-{@exposure_ids != ''} ? {			WHERE @exposure_id IN (@exposure_ids)}
+				@exposure_database_schema.@exposure_table et
+{@exposure_ids != ''} ? {			INNER JOIN tempdb..#scc_exposure_id sei ON sei.exposure_id = et.@exposure_id }
 		) raw_exposures
 {@first_exposure_only} ? {		WHERE rn1 = 1}
 	) t1
@@ -181,13 +181,13 @@ INNER JOIN (
 		outcome_id,
 		outcome_date
 	FROM (
-		SELECT @outcome_person_id AS person_id,
-			@outcome_id AS outcome_id,
-			@outcome_start_date AS outcome_date
-			{@first_outcome_only} ? {,ROW_NUMBER() OVER (PARTITION BY @outcome_person_id, @outcome_id ORDER BY @outcome_start_date) AS rn1}
+		SELECT ot.@outcome_person_id AS person_id,
+			ot.@outcome_id AS outcome_id,
+			ot.@outcome_start_date AS outcome_date
+			{@first_outcome_only} ? {,ROW_NUMBER() OVER (PARTITION BY ot.@outcome_person_id, ot.@outcome_id ORDER BY ot.@outcome_start_date) AS rn1}
 		FROM
-			@outcome_database_schema.@outcome_table
-{@outcome_ids != ''} ? {		WHERE @outcome_id IN (@outcome_ids)}
+			@outcome_database_schema.@outcome_table ot
+{@outcome_ids != ''} ? {		INNER JOIN tempdb..#scc_outcome_ids soi ON soi.outcome_id = ot.@outcome_id}
 	) raw_outcomes
 {@first_outcome_only} ? {	WHERE rn1 = 1}
 ) outcomes


### PR DESCRIPTION
Adding temporary tables with outcome and exposure cohort ids to allow package to run on a large (>10,000) number of cohorts where sql `WHERE IN (...)` queries would normally be used